### PR TITLE
support ComfyUI preview 3d node

### DIFF
--- a/IF_Trellis.py
+++ b/IF_Trellis.py
@@ -18,6 +18,14 @@ from trellis.utils import render_utils, postprocessing_utils
 
 logger = logging.getLogger("IF_Trellis")
 
+def get_subpath_after_dir(full_path, target_dir):
+    path_parts = full_path.split(os.sep)
+    try:
+        index = path_parts.index(target_dir)
+        return os.path.join(*path_parts[index + 1:])
+    except ValueError:
+        return None
+        
 class IF_TrellisImageTo3D:
     """ComfyUI node for converting images to 3D using TRELLIS."""
     
@@ -229,6 +237,8 @@ class IF_TrellisImageTo3D:
                     )
                     glb_path = os.path.join(out_dir, f"{project_name}.glb") 
                     glb.export(glb_path)
+                    glb_path = get_subpath_after_dir(glb_path, "output")
+                    
                 except Exception as e:
                     logger.error(f"Error exporting GLB: {str(e)}")
                     logger.error(traceback.format_exc())

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ kaolin==0.17.0
 spconv-cu120==2.3.6
 transformers==4.46.3
 gradio_litmodel3d==0.0.1
-https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.0.post2/flash_attn-2.7.0.post2+cu12torch2.4cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
+git+https://github.com/Dao-AILab/flash-attention
 https://huggingface.co/spaces/JeffreyXiang/TRELLIS/resolve/main/wheels/diff_gaussian_rasterization-0.0.0-cp310-cp310-linux_x86_64.whl?download=true
 https://huggingface.co/spaces/JeffreyXiang/TRELLIS/resolve/main/wheels/nvdiffrast-0.3.3-cp310-cp310-linux_x86_64.whl?download=true

--- a/trellis/renderers/gaussian_render.py
+++ b/trellis/renderers/gaussian_render.py
@@ -55,7 +55,7 @@ def render(viewpoint_camera, pc : Gaussian, pipe, bg_color : torch.Tensor, scali
     """
     # lazy import
     if 'GaussianRasterizer' not in globals():
-        from diff_gaussian_rasterization import GaussianRasterizer, GaussianRasterizationSettings
+        from diff_gauss import GaussianRasterizer, GaussianRasterizationSettings
     
     # Create zero tensor. We will use it to make pytorch return gradients of the 2D (screen-space) means
     screenspace_points = torch.zeros_like(pc.get_xyz, dtype=pc.get_xyz.dtype, requires_grad=True, device="cuda") + 0
@@ -75,8 +75,6 @@ def render(viewpoint_camera, pc : Gaussian, pipe, bg_color : torch.Tensor, scali
         image_width=int(viewpoint_camera.image_width),
         tanfovx=tanfovx,
         tanfovy=tanfovy,
-        kernel_size=kernel_size,
-        subpixel_offset=subpixel_offset,
         bg=bg_color,
         scale_modifier=scaling_modifier,
         viewmatrix=viewpoint_camera.world_view_transform,
@@ -121,15 +119,14 @@ def render(viewpoint_camera, pc : Gaussian, pipe, bg_color : torch.Tensor, scali
         colors_precomp = override_color
 
     # Rasterize visible Gaussians to image, obtain their radii (on screen). 
-    rendered_image, radii = rasterizer(
+    rendered_image, rendered_depth, rendered_norm, rendered_alpha, radii, extra = rasterizer(
         means3D = means3D,
         means2D = means2D,
         shs = shs,
         colors_precomp = colors_precomp,
         opacities = opacity,
         scales = scales,
-        rotations = rotations,
-        cov3D_precomp = cov3D_precomp
+        rotations = rotations
     )
 
     # Those Gaussians that were frustum culled or had a radius of 0 were not visible.


### PR DESCRIPTION
hi, 
I am the author of Load 3d node in ComfyUI, we talk on twitter previously~
Since I implment preview 3d node as well and would like to add support for your node.
In general, the preview 3d node need to read the file under "output" folder directly, and if the file path is something like:
**F:\ai-painting\ComfyUI\output\trellis_output\trellis_output.glb**
and the preview 3d node would need **trellis_output\trellis_output.glb** only, this is what I made in this PR.

Please notice preview 3d node still need one commit merging https://github.com/Comfy-Org/ComfyUI_frontend/pull/2005, and after it is merged, we also need Comfy main repo include the latest Frontend release. 

So this PR would be a preparation for these, I will let you know when these complete