### PR TITLE
Fix model auto downloading

### DIFF
--- a/IF_TrellisCheckpointLoader.py
+++ b/IF_TrellisCheckpointLoader.py
@@ -3,7 +3,6 @@ import os
 import logging
 import torch
 import huggingface_hub
-import requests
 import folder_paths
 from trellis_model_manager import TrellisModelManager
 from trellis.pipelines.trellis_image_to_3d import TrellisImageTo3DPipeline


### PR DESCRIPTION
## Related issues
- https://github.com/if-ai/ComfyUI-IF_Trellis/issues/25

## Summarize Changes
1. Right now it just raises an error instead of downloading models if there are no model files on the path, so add the auto model download logic.


Plus note, just as https://github.com/if-ai/ComfyUI-IF_Trellis/issues/9#issuecomment-2544636143 said, to enable these lines:

https://github.com/if-ai/ComfyUI-IF_Trellis/blob/a6a72ecaa12a493fd77950dd561277d140a97178/trellis_model_manager.py#L214-L217

We need to set `GITHUB_TOKEN` as an environment variable. Unless we get a `HTTP Error 401: Unauthorized` error. 
I think it would be better to put about this in the README.

