### PR TITLE
Fix remote url for `diff_gaussian_rasterization`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp39-win_amd64.whl; sys_platform == "win64" and python_version=="3.9"',
 
     # `diff_gaussian_rasterization` from source code
-    "git+https://github.com/graphdeco-inria/diff-gaussian-rasterization.git",
+    "git+https://github.com/autonomousvision/mip-splatting.git@main#subdirectory=submodules/diff-gaussian-rasterization",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,21 +29,21 @@ dependencies = [
     # triton for linux
     'triton; sys_platform == "linux"',
     # triton for windows
-    'https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp312-cp312-win_amd64.whl; sys_platform == "win64" and python_version=="3.12"',
-    'https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp311-cp311-win_amd64.whl; sys_platform == "win64" and python_version=="3.11"',
-    'https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp310-cp310-win_amd64.whl; sys_platform == "win64" and python_version=="3.10"',
-    'https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp38-cp38-win_amd64.whl; sys_platform == "win64" and python_version=="3.8"',
+    'https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp312-cp312-win_amd64.whl; sys_platform == "win64" and (python_version >= "3.12" and python_version < "3.13")',
+    'https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp311-cp311-win_amd64.whl; sys_platform == "win64" and (python_version >= "3.11" and python_version < "3.12")',
+    'https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp310-cp310-win_amd64.whl; sys_platform == "win64" and (python_version >= "3.10" and python_version < "3.11")',
+    'https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp38-cp38-win_amd64.whl; sys_platform == "win64" and (python_version >= "3.8" and python_version < "3.9")',
 
     # koalin for linux
-    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp312-linux_x86_64.whl; sys_platform == "linux" and python_version=="3.12"',
-    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp311-cp311-linux_x86_64.whl; sys_platform == "linux" and python_version=="3.11"',
-    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp310-cp310-linux_x86_64.whl; sys_platform == "linux" and python_version=="3.10"',
-    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp39-cp39-linux_x86_64.whl; sys_platform == "linux" and python_version=="3.9"',
+    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp312-linux_x86_64.whl; sys_platform == "linux" and (python_version >= "3.12" and python_version < "3.13")',
+    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp311-cp311-linux_x86_64.whl; sys_platform == "linux" and (python_version >= "3.11" and python_version < "3.12")',
+    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp310-cp310-linux_x86_64.whl; sys_platform == "linux" and (python_version >= "3.10" and python_version < "3.11")',
+    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp39-cp39-linux_x86_64.whl; sys_platform == "linux" and (python_version >= "3.9" and python_version < "3.10")',
     # koalin for windows
-    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp312-win_amd64.whl; sys_platform == "win64" and python_version=="3.12"',
-    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp311-cp311-win_amd64.whl; sys_platform == "win64" and python_version=="3.11"',
-    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp310-win_amd64.whl; sys_platform == "win64" and python_version=="3.10"',
-    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp39-win_amd64.whl; sys_platform == "win64" and python_version=="3.9"',
+    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp312-win_amd64.whl; sys_platform == "win64" and (python_version >= "3.12" and python_version < "3.13")',
+    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp311-cp311-win_amd64.whl; sys_platform == "win64" and (python_version >= "3.11" and python_version < "3.12")',
+    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp310-win_amd64.whl; sys_platform == "win64" and (python_version >= "3.10" and python_version < "3.11")',
+    'https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp39-cp39-win_amd64.whl; sys_platform == "win64" and (python_version >= "3.9" and python_version < "3.10")',
 
     # `diff_gaussian_rasterization` from source code
     "git+https://github.com/autonomousvision/mip-splatting.git@main#subdirectory=submodules/diff-gaussian-rasterization",

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ diffrp-nvdiffrast
 
 # koalin ( CUDA 12.4 specific builds from : https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124.html )
 # If you're not using CUDA 12.4, read official documentation at : https://kaolin.readthedocs.io/en/latest/notes/installation.html
-https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp312-linux_x86_64.whl;python_version=="3.12"
-https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp311-cp311-linux_x86_64.whl;python_version=="3.11"
-https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp310-cp310-linux_x86_64.whl;python_version=="3.10"
-https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp39-cp39-linux_x86_64.whl;python_version=="3.9"
+https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp312-linux_x86_64.whl; (python_version >= "3.12" and python_version < "3.13")
+https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp311-cp311-linux_x86_64.whl; (python_version >= "3.11" and python_version < "3.12")
+https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp310-cp310-linux_x86_64.whl; (python_version >= "3.10" and python_version < "3.11")
+https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp39-cp39-linux_x86_64.whl; (python_version >= "3.9" and python_version < "3.10")

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ spconv-cu124>=2.3.6
 #transformers>=4.46.3
 sageattention
 #git+https://github.com/Dao-AILab/flash-attention
-git+https://github.com/graphdeco-inria/diff-gaussian-rasterization.git
+git+https://github.com/autonomousvision/mip-splatting.git@main#subdirectory=submodules/diff-gaussian-rasterization
 diffrp-nvdiffrast
 
 # koalin ( CUDA 12.4 specific builds from : https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124.html )

--- a/trellis/renderers/gaussian_render.py
+++ b/trellis/renderers/gaussian_render.py
@@ -75,6 +75,8 @@ def render(viewpoint_camera, pc : Gaussian, pipe, bg_color : torch.Tensor, scali
         image_width=int(viewpoint_camera.image_width),
         tanfovx=tanfovx,
         tanfovy=tanfovy,
+        kernel_size=kernel_size,
+        subpixel_offset=subpixel_offset,
         bg=bg_color,
         scale_modifier=scaling_modifier,
         viewmatrix=viewpoint_camera.world_view_transform,

--- a/win_requirements.txt
+++ b/win_requirements.txt
@@ -28,7 +28,7 @@ https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0
 https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp39-cp39-win_amd64.whl;python_version=="3.9"
 
 # diff_gaussian_rasterization
-git+https://github.com/graphdeco-inria/diff-gaussian-rasterization.git
+git+https://github.com/autonomousvision/mip-splatting.git@main#subdirectory=submodules/diff-gaussian-rasterization
 
 # diffrp-nvdiffrast
 diffrp-nvdiffrast

--- a/win_requirements.txt
+++ b/win_requirements.txt
@@ -15,17 +15,17 @@ igraph
 spconv-cu124
 
 # triton ( Windows specific builds from : https://github.com/woct0rdho/triton-windows )
-https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp312-cp312-win_amd64.whl;python_version=="3.12"
-https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp311-cp311-win_amd64.whl;python_version=="3.11"
-https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp310-cp310-win_amd64.whl;python_version=="3.10"
-https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp38-cp38-win_amd64.whl;python_version=="3.8"
+https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp312-cp312-win_amd64.whl; (python_version >= "3.12" and python_version < "3.13")
+https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp311-cp311-win_amd64.whl; (python_version >= "3.11" and python_version < "3.12")
+https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp310-cp310-win_amd64.whl; (python_version >= "3.10" and python_version < "3.11")
+https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post8/triton-3.1.0-cp38-cp38-win_amd64.whl; (python_version >= "3.8" and python_version < "3.9")
 
 # koalin ( CUDA 12.4 specific builds from : https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124.html )
 # If you're not using CUDA 12.4, read official documentation at : https://kaolin.readthedocs.io/en/latest/notes/installation.html
-https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp312-win_amd64.whl;python_version=="3.12"
-https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp311-cp311-win_amd64.whl;python_version=="3.11"
-https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp310-cp310-win_amd64.whl;python_version=="3.10"
-https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp39-cp39-win_amd64.whl;python_version=="3.9"
+https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp312-cp312-win_amd64.whl; (python_version >= "3.12" and python_version < "3.13")
+https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp311-cp311-win_amd64.whl; (python_version >= "3.11" and python_version < "3.12")
+https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp310-cp310-win_amd64.whl; (python_version >= "3.10" and python_version < "3.11")
+https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.5.1_cu124/kaolin-0.17.0-cp39-cp39-win_amd64.whl; (python_version >= "3.9" and python_version < "3.10")
 
 # diff_gaussian_rasterization
 git+https://github.com/autonomousvision/mip-splatting.git@main#subdirectory=submodules/diff-gaussian-rasterization


### PR DESCRIPTION
## Related issues
- #51 
- https://github.com/if-ai/ComfyUI-IF_Trellis/issues/3#issuecomment-2545379575

## Summarize Changes
1. Referring to https://github.com/microsoft/TRELLIS/blob/eeacb0bf6a7d25058232d746bef4e5e880b130ff/setup.sh#L219, fix the remote URL for `diff_gaussian_rasterization`, and revert the changes to `GaussianRasterizationSettings()`. 
It works with the current version too, but should align with the original Trellis's. My bad.

2. Fix `python_version` markers in requirements, from `python_version=="3.12"` to `python_version >= "3.12" and python_version < "3.13"`