### PR TITLE
Ensuring texture log does not break if texture was not generated.

### DIFF
--- a/IF_Trellis.py
+++ b/IF_Trellis.py
@@ -243,7 +243,8 @@ class IF_TrellisImageTo3D:
         del mesh_output
         torch.cuda.empty_cache()
         
-        logger.info(f"Texture image shape: {texture_image.shape}")
+        if texture_image is not None:
+            logger.info(f"Texture image shape: {texture_image.shape}")
 
         return video_path, glb_path, texture_path, wireframe_path, texture_image, wireframe_image
 


### PR DESCRIPTION
Hello

If texture is not generated it can remain None and leads to an exception during one of the log.

Do you think this is acceptable as a fix ?

Regards